### PR TITLE
55 feat admin modification

### DIFF
--- a/frontend/src/components/Home/home.jsx
+++ b/frontend/src/components/Home/home.jsx
@@ -20,7 +20,8 @@ export default function Home() {
   };
 
   useEffect(() => {
-    fetchData("logged_hours-TEST").then((data) => {
+    fetchData("logged_hours_empty_2_TEST").then((data) => {
+      /// SHOULD BE logged_hours-TEST
       setLoggedHours(
         data.filter(
           (h) =>

--- a/frontend/src/components/Profile/profile.jsx
+++ b/frontend/src/components/Profile/profile.jsx
@@ -20,7 +20,8 @@ function Profile() {
   const csvLog = useRef(); // eslint-disable-line
 
   useEffect(() => {
-    fetchData("logged_hours-TEST").then((data) => {
+    fetchData("logged_hours_empty_2_TEST").then((data) => {
+      ///////SHOULD BE Logged_hours_TEST
       setAdminLoggedHours(
         data
           .filter((con) => con.username === "AdminLogged")

--- a/frontend/src/components/SignUp/SignUpForm.jsx
+++ b/frontend/src/components/SignUp/SignUpForm.jsx
@@ -96,9 +96,9 @@ function SignUpForm() {
           phonetwo = signUp.phonetwo;
         }
 
-        let medicalConditions = "None Specified";
-        if (signUp.medicalConditions) {
-          medicalConditions = signUp.medicalConditions;
+        let Medical_Conditions = "None Specified";
+        if (signUp.Medical_Conditions) {
+          Medical_Conditions = signUp.Medical_Conditions;
         }
 
         safetyStatus = false;
@@ -142,7 +142,7 @@ function SignUpForm() {
           Email: signUp.email,
           Birth_date: startDate,
           is_Admin: "False",
-          medicalConditions,
+          Medical_Conditions,
           "Safety Training Status": safetyStatus,
           "Photo-Permission": photoStatus,
           "Secondary Phone": phonetwo,
@@ -371,8 +371,8 @@ function SignUpForm() {
           <br />
           <Form.TextArea
             label="Medical Conditions"
-            name="medicalConditions"
-            value={signUp.medicalConditions}
+            name="Medical_Conditions"
+            value={signUp.Medical_Conditions}
             onChange={handleChange}
           />
           <div className="bool_top">

--- a/frontend/src/components/VolunteerTable/updateUserInfo.jsx
+++ b/frontend/src/components/VolunteerTable/updateUserInfo.jsx
@@ -1,0 +1,342 @@
+import React, { useState, useEffect, useContext } from "react";
+import { Form, Checkbox } from "semantic-ui-react";
+// import DatePicker from "react-datepicker";
+// import { Auth } from "aws-amplify";
+import { useNavigate, Link } from "react-router-dom";
+import { updatePersonalInfo, fetchUser } from "../../dynoFuncs";
+import { GlobalContext } from "../../GlobalState";
+
+function UpdateInfoForm() {
+  const { setCurrentUser, currentUserInfo } = useContext(GlobalContext);
+  // pass in user to user info in table
+  /// use fetch user from dynamo
+  // set that suer here, should be able to use the rest elsewhere
+  console.log("USER INFO_____________________________");
+  console.log(setCurrentUser);
+  console.log(currentUserInfo);
+  const formType = currentUserInfo.volunteerTable;
+  const [signUp, setSignUp] = useState({
+    Birth_date: currentUserInfo.Birth_date,
+    "Community Service": currentUserInfo["Community Service"],
+    Covid_Waiver_and_Release: currentUserInfo.Covid_Waiver_and_Release,
+    Email: currentUserInfo.Email,
+    Emergency_Contact: currentUserInfo.Emergency_Contact,
+    Emergency_Contact_Phone: currentUserInfo.Emergency_Contact_Phone,
+    "First Name": currentUserInfo["First Name"],
+    Group: currentUserInfo.Group,
+    "Last Name": currentUserInfo["Last Name"],
+    Medical_Conditions: currentUserInfo.Medical_Conditions,
+    "Photo-Permission": currentUserInfo["Photo-Permission"],
+    "Primary Phone": currentUserInfo["Primary Phone"],
+    "Safety Training Status": currentUserInfo["Safety Training Status"],
+    "Secondary Phone": currentUserInfo["Secondary Phone"],
+    Volunter_Waiver_and_Release: currentUserInfo.Volunter_Waiver_and_Release,
+    hourGoal: currentUserInfo.hourGoal,
+    is_Admin: currentUserInfo.is_Admin,
+    liveScanned: currentUserInfo.liveScanned,
+    mailing_address: currentUserInfo.mailing_address,
+    totalHours: currentUserInfo.totalHours,
+    userLoggedIn: currentUserInfo.userLoggedIn,
+    username: currentUserInfo.username,
+    volunteerTable: currentUserInfo.volunteerTable,
+  });
+
+  const [signUpGroup, setSignUpGroup] = useState({
+    emailContact: currentUserInfo.emailContact,
+    groupName: currentUserInfo.groupName,
+    hourGoal: currentUserInfo.hourGoal,
+    is_Admin: currentUserInfo.is_Admin,
+    phoneContact: currentUserInfo.phoneContact,
+    nameContact: currentUserInfo.nameContact,
+    safetyStatus: currentUserInfo.safetyStatus,
+    totalHours: currentUserInfo.totalHours,
+    userLoggedIn: currentUserInfo.userLoggedIn,
+    username: currentUserInfo.username,
+    volunteerTable: currentUserInfo.volunteerTable,
+  });
+  const handleChangeGroup = (e, { name, value }) =>
+    setSignUpGroup({ ...signUpGroup, [name]: value });
+  const handleChange = (e, { name, value }) =>
+    setSignUp({ ...signUp, [name]: value });
+  const [startDate, setStartDate] = useState(); // eslint-disable-line
+  const [refresh, setRefresh] = useState(); // eslint-disable-line
+  const [updateUser, setUpdateUser] = useState(0);
+  const navigate = useNavigate();
+
+  useEffect(() => {}, [refresh]);
+
+  useEffect(() => {
+    console.log("UPDATING CONTEXT");
+    fetchUser("volunteers_group-TEST", currentUserInfo.username).then(
+      (data) => {
+        let userInfo;
+        console.log("Fetch Group Data");
+        console.log(data);
+        userInfo = data;
+        if (!userInfo) {
+          fetchUser(
+            "volunteers_individual-TEST",
+            currentUserInfo.username
+          ).then((data) => {
+            // eslint-disable-line
+            userInfo = data;
+            userInfo.volunteerTable = "volunteers_individual-TEST";
+            userInfo.userLoggedIn = true;
+            setCurrentUser(userInfo);
+          });
+        } else {
+          userInfo.volunteerTable = "volunteers_group-TEST";
+          userInfo.userLoggedIn = true;
+          console.log(userInfo);
+          setCurrentUser(userInfo);
+        }
+      }
+    );
+    if (updateUser !== 0) {
+      navigate("/profile");
+    }
+  }, [updateUser]);
+
+  const updateData = () => {
+    if (currentUserInfo.volunteerTable === "volunteers_group-TEST") {
+      updatePersonalInfo(signUpGroup, "volunteers_group-TEST");
+    } else {
+      updatePersonalInfo(signUp, "volunteers_individual-TEST");
+    }
+    setUpdateUser(updateUser + 1);
+  };
+
+  console.log(currentUserInfo);
+  return (
+    <Form
+      className="signUpForm"
+      style={{ padding: "40px", display: "flex", flexDirection: "column" }}
+      onSubmit={updateData}
+    >
+      {formType === "volunteers_individual-TEST" && (
+        <div>
+          <h1
+            style={{
+              display: "flex",
+              justifyContent: "center",
+              paddingBottom: "5%",
+              fontWeight: "bold",
+            }}
+          >
+            Update Your Account's Personal Information
+          </h1>
+          <Form.Group widths="equal">
+            <Form.Input
+              label="First Name"
+              name="First Name"
+              value={signUp["First Name"]}
+              onChange={handleChange}
+              required
+            />
+            <Form.Input
+              label="Last Name"
+              name="Last Name"
+              value={signUp["Last Name"]}
+              onChange={handleChange}
+              required
+            />
+          </Form.Group>
+          <Form.Group widths="equal">
+            <Form.Input
+              label="Emergency Contact Phone Number"
+              name="Emergency_Contact_Phone"
+              value={signUp.Emergency_Contact_Phone}
+              onChange={handleChange}
+              required
+            />
+            <Form.Input
+              label="Emergency Contact Name"
+              name="Emergency_Contact"
+              value={signUp.Emergency_Contact}
+              onChange={handleChange}
+              required
+            />
+          </Form.Group>
+          <Form.Input
+            label="Group Name"
+            name="Group"
+            value={signUp.Group}
+            onChange={handleChange}
+          />
+          <Form.Input
+            label="Hour Goal"
+            name="hourGoal"
+            value={signUp.hourGoal}
+            onChange={handleChange}
+          />
+          <hr style={{ backgroundColor: "green", width: "100%" }} />
+          <Form.Input
+            label="Mailing Address"
+            name="mailing_address"
+            value={signUp.mailing_address}
+            onChange={handleChange}
+            required
+          />
+          <Form.Input
+            label="Phone Number"
+            name="Primary Phone"
+            value={signUp["Primary Phone"]}
+            onChange={handleChange}
+            required
+          />
+          <Form.Input
+            label="Secondary Phone Number"
+            name="Secondary Phone"
+            value={signUp["Secondary Phone"]}
+            onChange={handleChange}
+          />
+          <hr style={{ backgroundColor: "green", width: "100%" }} />
+          <h3 style={{ textAlign: "left" }}>Personal Information:</h3>
+          <label style={{ fontWeight: "bold" }}>Date of Birth</label>
+          <input
+            type="date"
+            onChange={(e) => {
+              setStartDate(e.target.value);
+            }}
+            required
+          />
+          <br />
+          <Form.TextArea
+            label="Medical Conditions"
+            name="Medical_Conditions"
+            value={signUp.Medical_Conditions}
+            onChange={handleChange}
+          />
+          <div className="bool_top">
+            <Checkbox
+              label="Safety Training Status Complete?"
+              checked={signUp["Safety Training Status"]}
+              onChange={(e, data) =>
+                setSignUp({ ...signUp, "Safety Training Status": data.checked })
+              }
+            />
+            <Checkbox
+              label="Volunteer Waiver and Release Complete?"
+              checked={signUp.Volunter_Waiver_and_Release}
+              onChange={(e, data) =>
+                setSignUp({
+                  ...signUp,
+                  Volunter_Waiver_and_Release: data.checked,
+                })
+              }
+            />
+            <Checkbox
+              label="Covid Waiver and Release Complete?"
+              checked={signUp.Covid_Waiver_and_Release}
+              onChange={(e, data) =>
+                setSignUp({ ...signUp, Covid_Waiver_and_Release: data.checked })
+              }
+            />
+            <br />
+          </div>
+          <div className="bool_top">
+            <Checkbox
+              checked={signUp["Community Service"]}
+              onChange={(e, data) =>
+                setSignUp({ ...signUp, "Community Service": data.checked })
+              }
+              label="Community Service?"
+            />
+            <Checkbox
+              label="Photo Permission?"
+              checked={signUp["Photo-Permission"]}
+              style={{ paddingBottom: "10px", paddingRight: "10%" }}
+              required
+              onChange={(e, data) =>
+                setSignUp({ ...signUp, "Photo-Permission": data.checked })
+              }
+            />
+            <Checkbox
+              className="liveScan"
+              label="Lived Scanned? (Need to work with children)"
+              checked={signUp.liveScanned}
+              style={{ paddingBottom: "10px" }}
+              required
+              onChange={(e, data) =>
+                setSignUp({ ...signUp, liveScanned: data.checked })
+              }
+            />
+          </div>
+          <br />
+          <br />
+        </div>
+      )}
+      {formType === "volunteers_group-TEST" && (
+        <Form>
+          <h1
+            style={{
+              display: "flex",
+              justifyContent: "center",
+              paddingBottom: "5%",
+              fontWeight: "bold",
+            }}
+          >
+            Update Your Account's Personal Information
+          </h1>
+          <Form.Group widths="equal">
+            <Form.Input
+              label="Name of Person of Contact"
+              name="nameContact"
+              value={signUpGroup.nameContact}
+              onChange={handleChangeGroup}
+              required
+            />
+            <Form.Input
+              label="Phone Number for Person of Contact"
+              name="phoneContact"
+              value={signUpGroup.phoneContact}
+              onChange={handleChangeGroup}
+              required
+            />
+          </Form.Group>
+          <Form.Input
+            label="Group Name"
+            name="groupName"
+            value={signUpGroup.groupName}
+            onChange={handleChangeGroup}
+            required
+          />
+          <Form.Input
+            label="Hour Goal"
+            name="hourGoal"
+            value={signUpGroup.hourGoal}
+            onChange={handleChangeGroup}
+          />
+
+          <Checkbox
+            label="Safety Training Status Complete?"
+            checked={signUpGroup.safetyStatus}
+            onChange={(e, data) =>
+              setSignUpGroup({ ...signUpGroup, safetyStatus: data.checked })
+            }
+          />
+        </Form>
+      )}
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          justifyContent: "space-around",
+        }}
+      >
+        {formType !== "" && (
+          <Link to="/profile">
+            <Form.Button content="Cancel Changes" />
+          </Link>
+        )}
+        {formType !== "" && (
+          // <Link to="/profile">
+          <Form.Button content="Update My Information" onSubmit={updateData} />
+          // </Link>
+        )}
+      </div>
+    </Form>
+  );
+}
+
+export default UpdateInfoForm;

--- a/frontend/src/components/VolunteerTable/updateUserInfo.jsx
+++ b/frontend/src/components/VolunteerTable/updateUserInfo.jsx
@@ -6,14 +6,39 @@ import { useNavigate, Link } from "react-router-dom";
 import { updatePersonalInfo, fetchUser } from "../../dynoFuncs";
 import { GlobalContext } from "../../GlobalState";
 
-function UpdateInfoForm() {
-  const { setCurrentUser, currentUserInfo } = useContext(GlobalContext);
+function UpdateInfoForm(props) {
+  // console.log("PROPS");
+  // console.log(props);
+  const [currentUserInfo, setCurrentUser] = useState(props.userMod);
+
+  // console.log("state");
+  // console.log(currentUserInfo);
+  // useEffect(() => {
+  //   console.log("new useeffect");
+  // }, []);
+  // const { currentUserInfo, setCurrentUser } = useState({});
   // pass in user to user info in table
   /// use fetch user from dynamo
   // set that suer here, should be able to use the rest elsewhere
-  console.log("USER INFO_____________________________");
-  console.log(setCurrentUser);
-  console.log(currentUserInfo);
+  // const { userToMod, setUserToMod } = fetchUser(
+  //   "volunteers_individual-TEST",
+  //   props.name
+  // );
+
+  // fetchUser("volunteers_individual-TEST", props.userName).then((data) => {
+  //   let userInfo;
+  //   // eslint-disable-line
+  //   userInfo = data;
+  //   console.log("userInfo");
+  //   console.log(userInfo);
+  //   userInfo.volunteerTable = "volunteers_individual-TEST";
+  //   userInfo.userLoggedIn = true;
+  //   setCurrentUser(userInfo);
+  // });
+  // console.log("PROPS:");
+  // console.log(props);
+  // console.log("PASSED USER INFO_____________________________");
+  // console.log(currentUserInfo);
   const formType = currentUserInfo.volunteerTable;
   const [signUp, setSignUp] = useState({
     Birth_date: currentUserInfo.Birth_date,
@@ -93,7 +118,7 @@ function UpdateInfoForm() {
       }
     );
     if (updateUser !== 0) {
-      navigate("/profile");
+      navigate("/volunteer");
     }
   }, [updateUser]);
 
@@ -104,6 +129,7 @@ function UpdateInfoForm() {
       updatePersonalInfo(signUp, "volunteers_individual-TEST");
     }
     setUpdateUser(updateUser + 1);
+    props.showFunc(false);
   };
 
   console.log(currentUserInfo);
@@ -198,7 +224,6 @@ function UpdateInfoForm() {
             onChange={(e) => {
               setStartDate(e.target.value);
             }}
-            required
           />
           <br />
           <Form.TextArea
@@ -325,13 +350,21 @@ function UpdateInfoForm() {
         }}
       >
         {formType !== "" && (
-          <Link to="/profile">
-            <Form.Button content="Cancel Changes" />
-          </Link>
+          <Form.Button
+            content="Cancel Changes"
+            onClick={(e) => {
+              e.preventDefault();
+              // console.log("hiding modal_______________________________-");
+              props.showFunc(false);
+            }}
+          />
         )}
         {formType !== "" && (
           // <Link to="/profile">
-          <Form.Button content="Update My Information" onSubmit={updateData} />
+          <Form.Button
+            content="Update User's Information"
+            onSubmit={updateData}
+          />
           // </Link>
         )}
       </div>

--- a/frontend/src/components/VolunteerTable/volunteerTable.js
+++ b/frontend/src/components/VolunteerTable/volunteerTable.js
@@ -21,6 +21,7 @@ import {
   changeVolunteerStatus,
 } from "../../dynoFuncs";
 import Navbar from "../Navbar/navbar";
+import UpdateInfoForm from "./updateUserInfo.jsx";
 
 const { CognitoIdentityServiceProvider } = require("aws-sdk");
 
@@ -60,13 +61,15 @@ function VolunteerTable() {
   const [csvReady, setCSVReady] = React.useState(false);
   const csvLog = useRef();
 
-  const reloadData = (() => {
-    fetchData("logged_hours-TEST").then((result) => setLoggedHours(result));
+  const reloadData = () => {
+    fetchData("logged_hours_empty_2_TEST").then((result) =>
+      setLoggedHours(result)
+    ); /// should be logged_hours-TEST
     fetchData("volunteers_group-TEST").then((result) => setGroup(result));
     fetchData("volunteers_individual-TEST").then((result) =>
       setVolunteers(result)
     );
-  });
+  };
 
   useEffect(() => {
     reloadData();
@@ -231,7 +234,7 @@ function VolunteerTable() {
               } else {
                 const logged = loggedHours
                   .filter(
-                    (obj) => 
+                    (obj) =>
                       new Date(obj.date).getTime() >=
                         startDate.target.valueAsNumber &&
                       new Date(obj.date).getTime() <=
@@ -291,6 +294,9 @@ function Table(props) {
   const [userToStatusChage, setUserToStatusChage] = React.useState();
   const [userStatus, setUserStatus] = React.useState("False");
 
+  const [showModify, setShowModify] = useState(false);
+  const [modifyingUserName, setModifyingUser] = useState("");
+
   const handleClickOpenDelete = (username) => {
     setUserToDelete(username);
     setDelete(true);
@@ -325,6 +331,15 @@ function Table(props) {
   const handleCancel = () => {
     setDelete(false);
     setStatus(false);
+  };
+
+  const handleModifyUser = (username) => {
+    setShowModify(true);
+    setModifyingUser(username);
+  };
+
+  const handleModifyCancel = () => {
+    setShowModify(false);
   };
 
   const columns = React.useMemo(
@@ -393,6 +408,21 @@ function Table(props) {
             </div>
           );
         },
+      },
+      {
+        Header: "Modify Info",
+        accessor: "Modify",
+        Cell: (row) => (
+          <div>
+            <div>
+              <button
+                onClick={() => handleModifyUser(row.row.original.username)}
+              >
+                Modify User Info
+              </button>
+            </div>
+          </div>
+        ),
       },
       {
         Header: "Delete Volunteer",
@@ -582,6 +612,28 @@ function Table(props) {
                   Cancel
                 </Button>
                 <Button onClick={handleStatusChange} color="#CCDDBD" autoFocus>
+                  Change User Status
+                </Button>
+              </DialogActions>
+            </DialogActions>
+          </Dialog>
+          <Dialog
+            open={showModify}
+            aria-labelledby="alert-dialog-title"
+            aria-describedby="alert-dialog-description"
+            maxWidth={1400}
+          >
+            <DialogTitle id="alert-dialog-title">
+              Modify user: {modifyingUserName}
+            </DialogTitle>
+            <DialogContent />
+            <DialogActions>
+              <UpdateInfoForm></UpdateInfoForm>
+              <DialogActions>
+                <Button onClick={handleModifyCancel} color="#CCDDBD">
+                  Cancel
+                </Button>
+                <Button onClick={handleModifyCancel} color="#CCDDBD" autoFocus>
                   Change User Status
                 </Button>
               </DialogActions>

--- a/frontend/src/components/VolunteerTable/volunteerTable.js
+++ b/frontend/src/components/VolunteerTable/volunteerTable.js
@@ -22,6 +22,7 @@ import {
 } from "../../dynoFuncs";
 import Navbar from "../Navbar/navbar";
 import UpdateInfoForm from "./updateUserInfo.jsx";
+import { fetchUser } from "../../dynoFuncs";
 
 const { CognitoIdentityServiceProvider } = require("aws-sdk");
 
@@ -83,22 +84,22 @@ function VolunteerTable() {
 
   const data = volunteers;
   const groupData = group;
-  console.log("VolunteerInfo 1");
-  console.log(data);
-  console.log(volunteers);
-  console.log(groupData);
-  console.log(group);
-  console.log(loggedHours);
-  console.log(groupData.length);
+  // console.log("VolunteerInfo 1");
+  // console.log(data);
+  // console.log(volunteers);
+  // console.log(groupData);
+  // console.log(group);
+  // console.log(loggedHours);
+  // console.log(groupData.length);
 
   if (!loggedHours || !currentUserInfo || !data || !groupData) return null;
 
   return (
     <>
-      {console.log("VolunteerInfo")}
+      {/* {console.log("VolunteerInfo")}
       {console.log(data)}
       {console.log(groupData)}
-      {console.log(loggedHours)}
+      {console.log(loggedHours)} */}
       <Navbar />
       <div
         style={{
@@ -295,7 +296,7 @@ function Table(props) {
   const [userStatus, setUserStatus] = React.useState("False");
 
   const [showModify, setShowModify] = useState(false);
-  const [modifyingUserName, setModifyingUser] = useState("");
+  const [modifyingUser, setModifyingUser] = useState("");
 
   const handleClickOpenDelete = (username) => {
     setUserToDelete(username);
@@ -333,13 +334,20 @@ function Table(props) {
     setStatus(false);
   };
 
-  const handleModifyUser = (username) => {
-    setShowModify(true);
-    setModifyingUser(username);
-  };
+  const handleModifyUser = async (username) => {
+    await fetchUser("volunteers_individual-TEST", username).then((data) => {
+      let userInfo;
+      // eslint-disable-line
+      userInfo = data;
 
-  const handleModifyCancel = () => {
-    setShowModify(false);
+      userInfo.volunteerTable = "volunteers_individual-TEST";
+      userInfo.userLoggedIn = false; ///////MAY NEED TO SET THS TO FALSE
+      // console.log("userInfo");
+      // console.log(userInfo);
+      setModifyingUser(userInfo);
+      // setCurrentUser(userInfo);
+    });
+    setShowModify(true);
   };
 
   const columns = React.useMemo(
@@ -416,7 +424,9 @@ function Table(props) {
           <div>
             <div>
               <button
-                onClick={() => handleModifyUser(row.row.original.username)}
+                onClick={async () =>
+                  handleModifyUser(row.row.original.username)
+                }
               >
                 Modify User Info
               </button>
@@ -624,19 +634,22 @@ function Table(props) {
             maxWidth={1400}
           >
             <DialogTitle id="alert-dialog-title">
-              Modify user: {modifyingUserName}
+              Modify user: {modifyingUser.username}
             </DialogTitle>
             <DialogContent />
             <DialogActions>
-              <UpdateInfoForm></UpdateInfoForm>
-              <DialogActions>
+              <UpdateInfoForm
+                userMod={modifyingUser}
+                showFunc={setShowModify}
+              ></UpdateInfoForm>
+              {/* <DialogActions>
                 <Button onClick={handleModifyCancel} color="#CCDDBD">
                   Cancel
                 </Button>
                 <Button onClick={handleModifyCancel} color="#CCDDBD" autoFocus>
                   Change User Status
                 </Button>
-              </DialogActions>
+              </DialogActions> */}
             </DialogActions>
           </Dialog>
         </Box>
@@ -652,6 +665,9 @@ function GroupTable(props) {
   const [openStatus, setStatus] = React.useState(false);
   const [userToStatusChage, setUserToStatusChage] = React.useState();
   const [userStatus, setUserStatus] = React.useState("False");
+
+  const [showModify, setShowModify] = useState(false);
+  const [modifyingGroup, setModifyingGroup] = useState("");
 
   const handleClickOpenDelete = (username) => {
     setUserToDelete(username);
@@ -687,6 +703,22 @@ function GroupTable(props) {
   const handleCancel = () => {
     setDelete(false);
     setStatus(false);
+  };
+
+  const handleModifyGroup = async (username) => {
+    await fetchUser("volunteers_group-TEST", username).then((data) => {
+      let groupInfo;
+      // eslint-disable-line
+      groupInfo = data;
+
+      groupInfo.volunteerTable = "volunteers_group-TEST";
+      groupInfo.userLoggedIn = false; ///////MAY NEED TO SET THS TO FALSE
+      // console.log("groupInfo");
+      // console.log(groupInfo);
+      setModifyingGroup(groupInfo);
+      // setCurrentUser(groupInfo);
+    });
+    setShowModify(true);
   };
 
   const columns = React.useMemo(
@@ -748,6 +780,23 @@ function GroupTable(props) {
             </div>
           );
         },
+      },
+      {
+        Header: "Modify Info",
+        accessor: "Modify",
+        Cell: (row) => (
+          <div>
+            <div>
+              <button
+                onClick={async () =>
+                  handleModifyGroup(row.row.original.username)
+                }
+              >
+                Modify User Info
+              </button>
+            </div>
+          </div>
+        ),
       },
       {
         Header: "Delete Volunteer",
@@ -941,6 +990,31 @@ function GroupTable(props) {
                   Change User Status
                 </Button>
               </DialogActions>
+            </DialogActions>
+          </Dialog>
+          <Dialog
+            open={showModify}
+            aria-labelledby="alert-dialog-title"
+            aria-describedby="alert-dialog-description"
+            maxWidth={1400}
+          >
+            <DialogTitle id="alert-dialog-title">
+              Modify group: {modifyingGroup.username}
+            </DialogTitle>
+            <DialogContent />
+            <DialogActions>
+              <UpdateInfoForm
+                userMod={modifyingGroup}
+                showFunc={setShowModify}
+              ></UpdateInfoForm>
+              {/* <DialogActions>
+                <Button onClick={handleModifyCancel} color="#CCDDBD">
+                  Cancel
+                </Button>
+                <Button onClick={handleModifyCancel} color="#CCDDBD" autoFocus>
+                  Change User Status
+                </Button>
+              </DialogActions> */}
             </DialogActions>
           </Dialog>
         </Box>

--- a/frontend/src/dynoFuncs.js
+++ b/frontend/src/dynoFuncs.js
@@ -19,10 +19,14 @@ export const fetchData = async (tableName) => {
   let cont = true;
   let ret = [];
 
+  console.log("params1:");
+  console.log(params);
   let entries = await new Promise((resolve, reject) => {
     docClient.scan(params, (err, data) => {
-      if (err) reject(err);
-      else resolve(data);
+      if (err) {
+        console.log(err);
+        reject(err);
+      } else resolve(data);
     });
   });
   ret = ret.concat(entries.Items);
@@ -34,7 +38,8 @@ export const fetchData = async (tableName) => {
     TableName: tableName,
     ExclusiveStartKey: entries.LastEvaluatedKey,
   };
-
+  console.log("params2:");
+  console.log(params);
   while (cont) {
     entries = await new Promise((resolve, reject) => {
       // eslint-disable-line
@@ -43,6 +48,7 @@ export const fetchData = async (tableName) => {
         else resolve(data);
       });
     });
+    // console.log("here");
     ret = ret.concat(entries.Items);
     if (!("LastEvaluatedKey" in entries)) {
       cont = false;
@@ -54,7 +60,8 @@ export const fetchData = async (tableName) => {
     }
   }
 
-  // console.log(ret);
+  console.log("RETURNED");
+  console.log(ret);
   return ret;
 };
 


### PR DESCRIPTION
Closes #55 

Allows admins to modify user information for the users and groups.
To test: 

1. login with admin credentials (message me for them)
2. Go to volunteers page
3. Go to my user on page 16 of the table (name is something long like "AFixBenjaminHackImpact", and you may have to sort the table), email is "bmcmann@calpoly.edu"
4. Click modify user info
5. Change some info
6. Try canceling and reloading to see if it actually canceled changes
7. Try modifying it again and click update user's information.
8. Make sure the info got updated
9. Try this again a few more times (maybe in different orders) **_but ONLY test it on this account_**. If you test on a random user's account it may change it in the live database
10. Repeat this process on the group page by hitting the group box on the top of the page 
11. Test on the "CalPolyH4ITest" **_**group account ONLY**_**

